### PR TITLE
Add default Collector comparer and extend coverage

### DIFF
--- a/packages/photon/src/core/collect.ts
+++ b/packages/photon/src/core/collect.ts
@@ -22,7 +22,10 @@ export interface ICollection<K, T> {
 export class Collector<K, T> {
         public collections: ICollection<K, T>[] = [];
 
-        constructor(private comparer?: ICollectionKeyComparer<K>) {
+        private comparer: ICollectionKeyComparer<K>;
+
+        constructor(comparer?: ICollectionKeyComparer<K>) {
+            this.comparer = comparer ?? ((a: K, b: K) => a === b);
         }
 
         public addItemToCollection(key: K, item: T) {

--- a/packages/photon/test/core.js
+++ b/packages/photon/test/core.js
@@ -106,4 +106,28 @@ describe('Core', function () {
     });
   });
 
+  describe('Collector', function () {
+
+    it('should default to strict equality when comparer not provided', function () {
+      var collector = new makerjs.collect.Collector();
+
+      collector.addItemToCollection('alpha', 1);
+      collector.addItemToCollection('alpha', 2);
+
+      assert.deepEqual(collector.findCollection('alpha'), [1, 2]);
+      assert.equal(collector.findCollection('beta'), null);
+    });
+
+    it('should treat different object references as different keys by default', function () {
+      var collector = new makerjs.collect.Collector();
+      var key1 = { id: 1 };
+      var key2 = { id: 1 };
+
+      collector.addItemToCollection(key1, 'first');
+      collector.addItemToCollection(key2, 'second');
+
+      assert.equal(collector.collections.length, 2);
+    });
+  });
+
 });


### PR DESCRIPTION
## Summary
- ensure the Collector class falls back to a strict-equality comparer when no custom comparer is provided
- extend the core test suite to cover Collector defaults and confirm distinct object keys remain separate

## Testing
- npm test *(fails: typedoc command not found in the build step of the test script)*

------
https://chatgpt.com/codex/tasks/task_e_68f78ffb3dd88321934979d908a81b25